### PR TITLE
Handle the case when a JS file fails to load

### DIFF
--- a/lazyLoadLight.js
+++ b/lazyLoadLight.js
@@ -56,13 +56,13 @@
 		//node.setAttribute('charset', 'utf-8');
 
 
-		node.onload = node.onreadystatechange = function () {
+		node.onload = node.onreadystatechange = node.onerror = function () {
 			var readyState = node.readyState;
 			if (	bDone === false
 					&& ( ! readyState || readyState == "loaded" || readyState == "complete" || readyState == "uninitialized" )
 				) {
 				// Handle memory leak in IE
-				node.onload = node.onreadystatechange = null;
+				node.onload = node.onreadystatechange = node.onerror = null;
 				finish(oFile);
 				bDone = true;
 			}


### PR DESCRIPTION
The use case: 

lazyLoadLight is called for a set of files.
One of the files is blocked by an addBlocker.
finish() is never called and bIsReading stays to true.

Then lazyLoadLight is called again for a new set of files.
readQueue() is not called.
